### PR TITLE
Leave RESULTS_EMAIL empty by default

### DIFF
--- a/build-and-bench.sh
+++ b/build-and-bench.sh
@@ -92,7 +92,6 @@ function run_perf_tests() {
 SELECTED_CC=${SELECTED_CC:-gcc-13}
 SELECTED_CXX=${SELECTED_CXX:-g++-13}
 ROOT_DIR=${ROOT_DIR:-/mnt/fast/build-and-bench}
-export RESULTS_EMAIL=${RESULTS_EMAIL:-przemyslaw.skibinski@percona.com}
 
 if [[ ${ENGINE} == "postgres" ]]; then
     SERVER_REPO_DIR=${SERVER_REPO_DIR:-$ROOT_DIR/postgres}


### PR DESCRIPTION
Currently it is set to a specific email address if it's empty, which means we can't disable the email sending feature. Later the email sending code checks for empty email, but it was impossible to specify because of this line.