### PR TITLE
Only execute apt on ubuntu/debian

### DIFF
--- a/build-and-bench.sh
+++ b/build-and-bench.sh
@@ -12,8 +12,10 @@ function install_deps_debian() {
     local PACKAGES_TO_INSTALL="smartmontools g++ dstat mutt ca-certificates git pkg-config dpkg-dev make cmake ccache bison linux-tools-$(uname -r) "
     PACKAGES_TO_INSTALL+="python-is-python3 python3-pip python3-pandas python3-requests"
     command -v sendmail >/dev/null 2>&1 || { PACKAGES_TO_INSTALL+=" sendmail"; }
-    sudo apt update
-    sudo apt -yq --no-install-suggests --no-install-recommends --allow-unauthenticated install $PACKAGES_TO_INSTALL $SELECTED_CXX
+    if [ -f /etc/lsb-release ]; then
+        sudo apt update
+        sudo apt -yq --no-install-suggests --no-install-recommends --allow-unauthenticated install $PACKAGES_TO_INSTALL $SELECTED_CXX
+    fi
 }
 
 function setup_git_repo() {
@@ -45,7 +47,9 @@ function build_sysbench() {
     if [ $# -lt 1 ]; then echo "Usage: build_sysbench <BUILD_DIR>"; return 1; fi
     local BUILD_DIR=$1
 
-    sudo apt -y install make automake libtool pkg-config libaio-dev libmysqlclient-dev libpq-dev libssl-dev
+    if [ -f /etc/lsb-release ]; then
+        sudo apt -y install make automake libtool pkg-config libaio-dev libmysqlclient-dev libpq-dev libssl-dev
+    fi
 
     pushd $BUILD_DIR
     ./autogen.sh

--- a/db-bench/mysql.inc
+++ b/db-bench/mysql.inc
@@ -15,7 +15,9 @@ function mysql_call_cmake() {
 
     local PACKAGES_LIBS="libtirpc-dev libgflags-dev libxml-simple-perl libeatmydata1 libfido2-dev libicu-dev libevent-dev libudev-dev libaio-dev libmecab-dev libnuma-dev liblz4-dev libzstd-dev libedit-dev libpam-dev libssl-dev libcurl4-openssl-dev libldap2-dev libkrb5-dev libsasl2-dev libsasl2-modules-gssapi-mit"
     local PACKAGES_PROTOBUF="protobuf-compiler libprotobuf-dev libprotoc-dev"
-    sudo apt -yq --no-install-suggests --no-install-recommends --allow-unauthenticated install $PACKAGES_LIBS $PACKAGES_PROTOBUF
+    if [ -f /etc/lsb-release ]; then
+        sudo apt -yq --no-install-suggests --no-install-recommends --allow-unauthenticated install $PACKAGES_LIBS $PACKAGES_PROTOBUF
+    fi
 
     rm -rf $BUILD_DIR
     mkdir -p $BUILD_DIR

--- a/db-bench/postgres.inc
+++ b/db-bench/postgres.inc
@@ -10,7 +10,9 @@ function build_postgres() {
     local REPO_DIR=$1
     local BIN_DIR=$2
 
-    sudo apt -y install build-essential libreadline-dev zlib1g-dev flex bison
+    if [ -f /etc/lsb-release ]; then
+        sudo apt -y install build-essential libreadline-dev zlib1g-dev flex bison
+    fi
 
     pushd $REPO_DIR
     ./configure --prefix=$BIN_DIR


### PR DESCRIPTION
Other systems most likely don't have this binary, so just skip it completely, and expect dependencies to be correctly set up manually.